### PR TITLE
Engine/Task: Increase default safety_mc value from 0.5 to 2

### DIFF
--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -36,7 +36,7 @@ TaskBehaviour::SetDefaults()
   calc_glide_required = true;
   goto_nonlandable = true;
   risk_gamma = 0;
-  safety_mc = 0.5;
+  safety_mc = 2;
   safety_height_arrival = 300;
   task_type_default = TaskFactoryType::RACING;
   start_margins.SetDefaults();


### PR DESCRIPTION
The original commit in https://github.com/XCSoar/XCSoar/pull/778 got dropped in a rebase, but I still think the issue is relevant, hence opening a new PR.

- When flying at optimal glide speed, a MC setting of 2 should give a pilot a bigger safety margin in terms of the reach area than 0.5 in case of unexpected sink

- MC 2 is a rather arbitrary value, but will give beginners not familiar with XCSoar enough to increase the value themselves a better chance of reaching their intended target

- Pilots flying in mountains should probably set this much higher; the value of 2 is intended as a starting point for flatlands
